### PR TITLE
Add index argument to onNewRequest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-form-material-ui",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "An adapter between Redux Form and Material UI components",
   "main": "./lib/index.js",
   "jsnext:main": "./es/index.js",

--- a/src/AutoComplete.js
+++ b/src/AutoComplete.js
@@ -8,10 +8,10 @@ export default createComponent(
     ...mapError(props),
     ...inputProps,
     searchText: dataSourceConfig ? value[dataSourceConfig.text] : value,
-    onNewRequest: value => {
+    onNewRequest: (value, index) => {
       inputProps.onChange(value)
       if(onNewRequestFunc && typeof onNewRequestFunc === 'function') {
-        onNewRequestFunc(value)
+        onNewRequestFunc(value, index)
       }
     }
   }))


### PR DESCRIPTION
`index` was missing from the [AutoComplete](http://www.material-ui.com/#/components/auto-complete) `onNewRequest` function
`function(chosenRequest: string, index: number) => { }`